### PR TITLE
Consistent usage of "multiplicity"

### DIFF
--- a/contents/mapping-yaml-specification.md
+++ b/contents/mapping-yaml-specification.md
@@ -83,11 +83,11 @@ It MUST have a `name` key with a string value representing the name of the [=rel
 
 It MUST have a `target` key with an [=ObjectTypeRef node=] value, representing the target [=object type=] of the [=relation=].
 
-It MUST have a `cardinality` key with a valid cardinality string value.
+It MUST have a `multiplicity` key with a valid multiplicity string value.
 
 It MUST have an `inverseName` key with a string value representing the inverse name of the [=relation=].
 
-It MUST have an `inverseCardinality` key with a string value representing the inverse cardinality of the [=relation=].
+It MUST have an `inverseMultiplicity` key with a string value representing the inverse multiplicity of the [=relation=].
 
 It MUST either have:
 * a `keyMapping` key whose value is a [=KeyMapping node=].

--- a/contents/model-representation.md
+++ b/contents/model-representation.md
@@ -80,7 +80,7 @@ _Overview attributes_
 |---------------|--------------|-------------------------------------------------|
 | name          | 1..1         | The name of the property.                       |
 | isIdentifier  | 1..1         | Indication whether the property is identifying. |
-| multiplicity  | 1..1         | The [=multiplicity=] of the property.            |
+| multiplicity  | 1..1         | The [=multiplicity=] of the property.           |
 
 ### Multiplicity (`Multiplicity`)
 
@@ -100,11 +100,11 @@ A <dfn>relation</dfn> is a [=property=] which expresses a relationship between t
 
 _Overview attributes_
 
-| Name               | Multiplicity | Definition                                                                                                                    |
-|--------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------|
-| inverseName        | 1..1         | The inverse name of the [=relation=], to be used to traverse the relation in the inverse direction.                           |
-| inverseCardinality | 1..1         | The inverse cardinality of the [=relation=].                                                                                  |
-| keyMapping         | 0..1         | A map (String -> Object) defining the mapping the source [=object type=] key [=properties=] to the target key [=properties=]. |
+| Name                | Multiplicity | Definition                                                                                                                    |
+|---------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------|
+| inverseName         | 1..1         | The inverse name of the [=relation=], to be used to traverse the relation in the inverse direction.                           |
+| inverseMultiplicity | 1..1         | The inverse multiplicity of the [=relation=].                                                                                 |
+| keyMapping          | 0..1         | A map (String -> Object) defining the mapping the source [=object type=] key [=properties=] to the target key [=properties=]. |
 
 _Overview relations_
 


### PR DESCRIPTION
In a few cases, the (incorrect) term `cardinality` was still being used.